### PR TITLE
Improve HTML examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,34 +33,34 @@ Parameters:
 
 Markdown
 
-```
+```md
 [![Lighthouse score: 100/100](https://lighthouse-badge.appspot.com/?score=100)](https://github.com/ebidel/lighthouse-badge)
 ```
 
-```
+```md
 [![Lighthouse score: 85/100](https://lighthouse-badge.appspot.com/?score=85&compact&category=PWA)](https://github.com/ebidel/lighthouse-badge)
 ```
 
-```
+```md
 [![Lighthouse score: 65/100](https://lighthouse-badge.appspot.com/?score=65&compact)](https://github.com/ebidel/lighthouse-badge)
 ```
 
 HTML
 
-```
-<a href="https://github.com/ebidel/lighthouse-badge" target="_blank">
+```html
+<a href="https://github.com/ebidel/lighthouse-badge" target="_blank" rel="noopener">
   <img src="https://lighthouse-badge.appspot.com?score=100">
 </a>
 ```
 
-```
-<a href="https://github.com/ebidel/lighthouse-badge" target="_blank">
-  <img src="https://lighthouse-badge.appspot.com?score=85&category=PWA">
+```html
+<a href="https://github.com/ebidel/lighthouse-badge" target="_blank" rel="noopener">
+  <img src="https://lighthouse-badge.appspot.com?score=85&amp;category=PWA">
 </a>
 ```
 
-```
-<a href="https://github.com/ebidel/lighthouse-badge" target="_blank">
-  <img src="https://lighthouse-badge.appspot.com?score=165&compact">
+```html
+<a href="https://github.com/ebidel/lighthouse-badge" target="_blank" rel="noopener">
+  <img src="https://lighthouse-badge.appspot.com?score=165&amp;compact">
 </a>
 ```


### PR DESCRIPTION
1. Add rel="noopener" because target="_blank" is used: https://mathiasbynens.github.io/rel-noopener/
2. HTML-encode ampersands.